### PR TITLE
add support for setting ns-prefix on Signature

### DIFF
--- a/src/templates.rs
+++ b/src/templates.rs
@@ -12,14 +12,12 @@ use crate::XmlSecError;
 use crate::XmlSecResult;
 
 use std::ffi::CString;
-use std::ptr::null;
 use std::os::raw::c_uchar;
-
+use std::ptr::null;
 
 /// Declaration of a template building API for other specific trait extensions
 /// on foreign XML objects.
-pub trait TemplateBuilder
-{
+pub trait TemplateBuilder {
     /// Sets canonicalization method. See: [`XmlSecCanonicalizationMethod`][c14n].
     ///
     /// [c14n]: ./transforms/enum.XmlSecCanonicalizationMethod.html
@@ -32,6 +30,9 @@ pub trait TemplateBuilder
 
     /// Sets signature subject node URI
     fn uri(self, uri: &str) -> Self;
+
+    /// the namespace prefix for the signature element (e.g. "dsig")
+    fn ns_prefix(self, ns_prefix: &str) -> Self;
 
     /// Adds <ds:KeyName> to key information node
     fn keyname(self, add: bool) -> Self;
@@ -46,112 +47,110 @@ pub trait TemplateBuilder
     fn done(self) -> XmlSecResult<()>;
 }
 
-
 /// Trait extension aimed at a concrete implementation for [`XmlDocument`][xmldoc]
 ///
 /// [xmldoc]: http://kwarc.github.io/rust-libxml/libxml/tree/document/struct.Document.html
-pub trait XmlDocumentTemplating<'d>
-{
+pub trait XmlDocumentTemplating<'d> {
     /// Return a template builder over current XmlDocument.
     fn template(&'d self) -> XmlDocumentTemplateBuilder<'d>;
 }
 
-
 /// Concrete template builder for [`XmlDocument`][xmldoc]
 ///
 /// [xmldoc]: http://kwarc.github.io/rust-libxml/libxml/tree/document/struct.Document.html
-pub struct XmlDocumentTemplateBuilder<'d>
-{
-    doc:     &'d XmlDocument,
+pub struct XmlDocumentTemplateBuilder<'d> {
+    doc: &'d XmlDocument,
     options: TemplateOptions,
 }
 
-
-struct TemplateOptions
-{
+struct TemplateOptions {
     c14n: XmlSecCanonicalizationMethod,
-    sig:  XmlSecSignatureMethod,
+    sig: XmlSecSignatureMethod,
+
+    ns_prefix: Option<String>,
 
     uri: Option<String>,
 
-    keyname:  bool,
+    keyname: bool,
     keyvalue: bool,
     x509data: bool,
 }
 
-
-impl Default for TemplateOptions
-{
-    fn default() -> Self
-    {
+impl Default for TemplateOptions {
+    fn default() -> Self {
         Self {
             c14n: XmlSecCanonicalizationMethod::ExclusiveC14N,
-            sig:  XmlSecSignatureMethod::RsaSha1,
+            sig: XmlSecSignatureMethod::RsaSha1,
 
             uri: None,
+            ns_prefix: None,
 
-            keyname:  false,
+            keyname: false,
             keyvalue: false,
             x509data: false,
         }
     }
 }
 
-
-impl<'d> XmlDocumentTemplating<'d> for XmlDocument
-{
-    fn template(&'d self) -> XmlDocumentTemplateBuilder<'d>
-    {
+impl<'d> XmlDocumentTemplating<'d> for XmlDocument {
+    fn template(&'d self) -> XmlDocumentTemplateBuilder<'d> {
         crate::xmlsec::guarantee_xmlsec_init();
 
-        XmlDocumentTemplateBuilder {doc: self, options: TemplateOptions::default()}
+        XmlDocumentTemplateBuilder {
+            doc: self,
+            options: TemplateOptions::default(),
+        }
     }
 }
 
-
-impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
-{
-    fn canonicalization(mut self, c14n: XmlSecCanonicalizationMethod) -> Self
-    {
+impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d> {
+    fn canonicalization(mut self, c14n: XmlSecCanonicalizationMethod) -> Self {
         self.options.c14n = c14n;
         self
     }
 
-    fn signature(mut self, sig: XmlSecSignatureMethod) -> Self
-    {
+    fn signature(mut self, sig: XmlSecSignatureMethod) -> Self {
         self.options.sig = sig;
         self
     }
 
-    fn uri(mut self, uri: &str) -> Self
-    {
+    fn uri(mut self, uri: &str) -> Self {
         self.options.uri = Some(uri.to_owned());
         self
     }
 
-    fn keyname(mut self, add: bool) -> Self
-    {
+    fn ns_prefix(mut self, ns_prefix: &str) -> Self {
+        self.options.ns_prefix = Some(ns_prefix.to_owned());
+        self
+    }
+
+    fn keyname(mut self, add: bool) -> Self {
         self.options.keyname = add;
         self
     }
 
-    fn keyvalue(mut self, add: bool) -> Self
-    {
+    fn keyvalue(mut self, add: bool) -> Self {
         self.options.keyvalue = add;
         self
     }
 
-    fn x509data(mut self, add: bool) -> Self
-    {
+    fn x509data(mut self, add: bool) -> Self {
         self.options.x509data = add;
         self
     }
 
-    fn done(self) -> XmlSecResult<()>
-    {
+    fn done(self) -> XmlSecResult<()> {
         let curi = {
             if let Some(uri) = self.options.uri {
                 CString::new(uri).unwrap().into_raw() as *const c_uchar
+            } else {
+                null()
+            }
+        };
+
+        let c_ns_prefix = {
+            if let Some(ns_prefix) = self.options.ns_prefix {
+                CString::new(ns_prefix).unwrap().into_raw() as *const c_uchar
             } else {
                 null()
             }
@@ -168,30 +167,40 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             return Err(XmlSecError::RootNotFound);
         }
 
-        let signature = unsafe { bindings::xmlSecTmplSignatureCreate(
-            docptr,
-            self.options.c14n.to_method(),
-            self.options.sig.to_method(),
-            null()
-        ) };
+        let signature = unsafe {
+            bindings::xmlSecTmplSignatureCreateNsPref(
+                docptr,
+                self.options.c14n.to_method(),
+                self.options.sig.to_method(),
+                null(),
+                c_ns_prefix,
+            )
+        };
 
         if signature.is_null() {
             panic!("Failed to create signature template");
         }
 
-        let reference = unsafe { bindings::xmlSecTmplSignatureAddReference(
-            signature,
-            XmlSecSignatureMethod::Sha1.to_method(),
-            null(),
-            curi,
-            null()
-        ) };
+        let reference = unsafe {
+            bindings::xmlSecTmplSignatureAddReference(
+                signature,
+                XmlSecSignatureMethod::Sha1.to_method(),
+                null(),
+                curi,
+                null(),
+            )
+        };
 
         if reference.is_null() {
             panic!("Failed to add enveloped transform to reference");
         }
 
-        let envelope = unsafe { bindings::xmlSecTmplReferenceAddTransform(reference, bindings::xmlSecTransformEnvelopedGetKlass()) };
+        let envelope = unsafe {
+            bindings::xmlSecTmplReferenceAddTransform(
+                reference,
+                bindings::xmlSecTransformEnvelopedGetKlass(),
+            )
+        };
 
         if envelope.is_null() {
             panic!("Failed to add enveloped transform")
@@ -203,8 +212,7 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             panic!("Failed to ensure key info");
         }
 
-        if self.options.keyname
-        {
+        if self.options.keyname {
             let keyname = unsafe { bindings::xmlSecTmplKeyInfoAddKeyName(keyinfo, null()) };
 
             if keyname.is_null() {
@@ -212,8 +220,7 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             }
         }
 
-        if self.options.keyvalue
-        {
+        if self.options.keyvalue {
             let keyvalue = unsafe { bindings::xmlSecTmplKeyInfoAddKeyValue(keyinfo) };
 
             if keyvalue.is_null() {
@@ -221,8 +228,7 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             }
         }
 
-        if self.options.x509data
-        {
+        if self.options.x509data {
             let x509data = unsafe { bindings::xmlSecTmplKeyInfoAddX509Data(keyinfo) };
 
             if x509data.is_null() {
@@ -232,8 +238,10 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
 
         unsafe { bindings::xmlAddChild(rootptr, signature) };
 
-        if ! curi.is_null() {
-            unsafe { CString::from_raw(curi as *mut i8); }
+        if !curi.is_null() {
+            unsafe {
+                CString::from_raw(curi as *mut i8);
+            }
         }
 
         Ok(())

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -62,7 +62,7 @@ pub trait XmlDocumentTemplating<'d>
 /// [xmldoc]: http://kwarc.github.io/rust-libxml/libxml/tree/document/struct.Document.html
 pub struct XmlDocumentTemplateBuilder<'d>
 {
-    doc: &'d XmlDocument,
+    doc:     &'d XmlDocument,
     options: TemplateOptions,
 }
 
@@ -181,26 +181,24 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
         }
 
         let signature = unsafe { bindings::xmlSecTmplSignatureCreateNsPref(
-                docptr,
-                self.options.c14n.to_method(),
-                self.options.sig.to_method(),
-                null(),
-                c_ns_prefix,
-            )
-        };
+            docptr,
+            self.options.c14n.to_method(),
+            self.options.sig.to_method(),
+            null(),
+            c_ns_prefix,
+        ) };
 
         if signature.is_null() {
             panic!("Failed to create signature template");
         }
 
         let reference = unsafe { bindings::xmlSecTmplSignatureAddReference(
-                signature,
-                XmlSecSignatureMethod::Sha1.to_method(),
-                null(),
-                curi,
-                null(),
-            )
-        };
+            signature,
+            XmlSecSignatureMethod::Sha1.to_method(),
+            null(),
+            curi,
+            null(),
+        ) };
 
         if reference.is_null() {
             panic!("Failed to add enveloped transform to reference");
@@ -218,7 +216,8 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             panic!("Failed to ensure key info");
         }
 
-        if self.options.keyname {
+        if self.options.keyname
+        {
             let keyname = unsafe { bindings::xmlSecTmplKeyInfoAddKeyName(keyinfo, null()) };
 
             if keyname.is_null() {
@@ -226,7 +225,8 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             }
         }
 
-        if self.options.keyvalue {
+        if self.options.keyvalue
+        {
             let keyvalue = unsafe { bindings::xmlSecTmplKeyInfoAddKeyValue(keyinfo) };
 
             if keyvalue.is_null() {
@@ -234,7 +234,8 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             }
         }
 
-        if self.options.x509data {
+        if self.options.x509data
+        {
             let x509data = unsafe { bindings::xmlSecTmplKeyInfoAddX509Data(keyinfo) };
 
             if x509data.is_null() {

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -17,7 +17,8 @@ use std::ptr::null;
 
 /// Declaration of a template building API for other specific trait extensions
 /// on foreign XML objects.
-pub trait TemplateBuilder {
+pub trait TemplateBuilder
+{
     /// Sets canonicalization method. See: [`XmlSecCanonicalizationMethod`][c14n].
     ///
     /// [c14n]: ./transforms/enum.XmlSecCanonicalizationMethod.html
@@ -50,7 +51,8 @@ pub trait TemplateBuilder {
 /// Trait extension aimed at a concrete implementation for [`XmlDocument`][xmldoc]
 ///
 /// [xmldoc]: http://kwarc.github.io/rust-libxml/libxml/tree/document/struct.Document.html
-pub trait XmlDocumentTemplating<'d> {
+pub trait XmlDocumentTemplating<'d>
+{
     /// Return a template builder over current XmlDocument.
     fn template(&'d self) -> XmlDocumentTemplateBuilder<'d>;
 }
@@ -58,12 +60,14 @@ pub trait XmlDocumentTemplating<'d> {
 /// Concrete template builder for [`XmlDocument`][xmldoc]
 ///
 /// [xmldoc]: http://kwarc.github.io/rust-libxml/libxml/tree/document/struct.Document.html
-pub struct XmlDocumentTemplateBuilder<'d> {
+pub struct XmlDocumentTemplateBuilder<'d>
+{
     doc: &'d XmlDocument,
     options: TemplateOptions,
 }
 
-struct TemplateOptions {
+struct TemplateOptions
+{
     c14n: XmlSecCanonicalizationMethod,
     sig: XmlSecSignatureMethod,
 
@@ -76,8 +80,10 @@ struct TemplateOptions {
     x509data: bool,
 }
 
-impl Default for TemplateOptions {
-    fn default() -> Self {
+impl Default for TemplateOptions
+{
+    fn default() -> Self
+    {
         Self {
             c14n: XmlSecCanonicalizationMethod::ExclusiveC14N,
             sig: XmlSecSignatureMethod::RsaSha1,
@@ -92,8 +98,10 @@ impl Default for TemplateOptions {
     }
 }
 
-impl<'d> XmlDocumentTemplating<'d> for XmlDocument {
-    fn template(&'d self) -> XmlDocumentTemplateBuilder<'d> {
+impl<'d> XmlDocumentTemplating<'d> for XmlDocument
+{
+    fn template(&'d self) -> XmlDocumentTemplateBuilder<'d>
+    {
         crate::xmlsec::guarantee_xmlsec_init();
 
         XmlDocumentTemplateBuilder {
@@ -103,43 +111,52 @@ impl<'d> XmlDocumentTemplating<'d> for XmlDocument {
     }
 }
 
-impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d> {
-    fn canonicalization(mut self, c14n: XmlSecCanonicalizationMethod) -> Self {
+impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
+{
+    fn canonicalization(mut self, c14n: XmlSecCanonicalizationMethod) -> Self
+    {
         self.options.c14n = c14n;
         self
     }
 
-    fn signature(mut self, sig: XmlSecSignatureMethod) -> Self {
+    fn signature(mut self, sig: XmlSecSignatureMethod) -> Self
+    {
         self.options.sig = sig;
         self
     }
 
-    fn uri(mut self, uri: &str) -> Self {
+    fn uri(mut self, uri: &str) -> Self
+    {
         self.options.uri = Some(uri.to_owned());
         self
     }
 
-    fn ns_prefix(mut self, ns_prefix: &str) -> Self {
+    fn ns_prefix(mut self, ns_prefix: &str) -> Self
+    {
         self.options.ns_prefix = Some(ns_prefix.to_owned());
         self
     }
 
-    fn keyname(mut self, add: bool) -> Self {
+    fn keyname(mut self, add: bool) -> Self
+    {
         self.options.keyname = add;
         self
     }
 
-    fn keyvalue(mut self, add: bool) -> Self {
+    fn keyvalue(mut self, add: bool) -> Self
+    {
         self.options.keyvalue = add;
         self
     }
 
-    fn x509data(mut self, add: bool) -> Self {
+    fn x509data(mut self, add: bool) -> Self
+    {
         self.options.x509data = add;
         self
     }
 
-    fn done(self) -> XmlSecResult<()> {
+    fn done(self) -> XmlSecResult<()>
+    {
         let curi = {
             if let Some(uri) = self.options.uri {
                 CString::new(uri).unwrap().into_raw() as *const c_uchar

--- a/src/templates.rs
+++ b/src/templates.rs
@@ -69,13 +69,12 @@ pub struct XmlDocumentTemplateBuilder<'d>
 struct TemplateOptions
 {
     c14n: XmlSecCanonicalizationMethod,
-    sig: XmlSecSignatureMethod,
+    sig:  XmlSecSignatureMethod,
 
     ns_prefix: Option<String>,
+    uri:       Option<String>,
 
-    uri: Option<String>,
-
-    keyname: bool,
+    keyname:  bool,
     keyvalue: bool,
     x509data: bool,
 }
@@ -86,12 +85,12 @@ impl Default for TemplateOptions
     {
         Self {
             c14n: XmlSecCanonicalizationMethod::ExclusiveC14N,
-            sig: XmlSecSignatureMethod::RsaSha1,
+            sig:  XmlSecSignatureMethod::RsaSha1,
 
-            uri: None,
+            uri:       None,
             ns_prefix: None,
 
-            keyname: false,
+            keyname:  false,
             keyvalue: false,
             x509data: false,
         }
@@ -104,10 +103,7 @@ impl<'d> XmlDocumentTemplating<'d> for XmlDocument
     {
         crate::xmlsec::guarantee_xmlsec_init();
 
-        XmlDocumentTemplateBuilder {
-            doc: self,
-            options: TemplateOptions::default(),
-        }
+        XmlDocumentTemplateBuilder {doc: self, options: TemplateOptions::default()}
     }
 }
 
@@ -184,8 +180,7 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             return Err(XmlSecError::RootNotFound);
         }
 
-        let signature = unsafe {
-            bindings::xmlSecTmplSignatureCreateNsPref(
+        let signature = unsafe { bindings::xmlSecTmplSignatureCreateNsPref(
                 docptr,
                 self.options.c14n.to_method(),
                 self.options.sig.to_method(),
@@ -198,8 +193,7 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             panic!("Failed to create signature template");
         }
 
-        let reference = unsafe {
-            bindings::xmlSecTmplSignatureAddReference(
+        let reference = unsafe { bindings::xmlSecTmplSignatureAddReference(
                 signature,
                 XmlSecSignatureMethod::Sha1.to_method(),
                 null(),
@@ -212,12 +206,7 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
             panic!("Failed to add enveloped transform to reference");
         }
 
-        let envelope = unsafe {
-            bindings::xmlSecTmplReferenceAddTransform(
-                reference,
-                bindings::xmlSecTransformEnvelopedGetKlass(),
-            )
-        };
+        let envelope = unsafe { bindings::xmlSecTmplReferenceAddTransform(reference, bindings::xmlSecTransformEnvelopedGetKlass()) };
 
         if envelope.is_null() {
             panic!("Failed to add enveloped transform")
@@ -256,9 +245,7 @@ impl<'d> TemplateBuilder for XmlDocumentTemplateBuilder<'d>
         unsafe { bindings::xmlAddChild(rootptr, signature) };
 
         if !curi.is_null() {
-            unsafe {
-                CString::from_raw(curi as *mut i8);
-            }
+            unsafe { CString::from_raw(curi as *mut i8); }
         }
 
         Ok(())

--- a/tests/resources/sign2-tmpl-ns-prefix-dsig.xml
+++ b/tests/resources/sign2-tmpl-ns-prefix-dsig.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+XML Security Library example: Original XML doc file for sign2 example.
+-->
+<Envelope xmlns="urn:envelope">
+  <Data>
+	Hello, World!
+  </Data>
+<dsig:Signature xmlns:dsig="http://www.w3.org/2000/09/xmldsig#">
+<dsig:SignedInfo>
+<dsig:CanonicalizationMethod Algorithm="http://www.w3.org/2001/10/xml-exc-c14n#"/>
+<dsig:SignatureMethod Algorithm="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+<dsig:Reference URI="ReferencedID">
+<dsig:Transforms>
+<dsig:Transform Algorithm="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+</dsig:Transforms>
+<dsig:DigestMethod Algorithm="http://www.w3.org/2000/09/xmldsig#sha1"/>
+<dsig:DigestValue/>
+</dsig:Reference>
+</dsig:SignedInfo>
+<dsig:SignatureValue/>
+<dsig:KeyInfo>
+<dsig:KeyName/>
+<dsig:KeyValue/>
+<dsig:X509Data/>
+</dsig:KeyInfo>
+</dsig:Signature></Envelope>

--- a/tests/test_templating.rs
+++ b/tests/test_templating.rs
@@ -36,3 +36,32 @@ fn test_template_creation()
 
     assert_eq!(doc.to_string(), reference);
 }
+
+#[test]
+fn test_template_creation_with_ns_prefix()
+{
+    // load document
+    let parser = XmlParser::default();
+
+    let doc = parser.parse_file("tests/resources/sign2-doc.xml")
+        .expect("Could not load template document");
+
+    // add signature node structure
+    doc.template()
+        .canonicalization(XmlSecCanonicalizationMethod::ExclusiveC14N)
+        .signature(XmlSecSignatureMethod::RsaSha1)
+        .ns_prefix("dsig")
+        .keyname(true)
+        .keyvalue(true)
+        .x509data(true)
+        .uri("ReferencedID")
+        .done()
+        .expect("Failed to build and attach signature");
+
+    // compare template results
+    let reference = String::from_utf8(
+        include_bytes!("./resources/sign2-tmpl-ns-prefix-dsig.xml").to_vec()
+    ).unwrap();
+
+    assert_eq!(doc.to_string(), reference);
+}


### PR DESCRIPTION
I had a use case that needed the namespace prefix defined.  Here is my PR for it if you want to bring it into the library.

https://www.aleksey.com/xmlsec/api/xmlsec-templates.html#xmlSecTmplSignatureCreateNsPref


While I have your attention, I was wondering if you'd entertain this use case for your library.  I need to have the x509 data in a specific format that has more information than I get by associating them in the manner supported by the library right now:

```
    for cert in chain {
        let cert =
            key.load_cert_from_memory(&cert.pem, XmlSecKeyFormat::Pem);
    }
```

This lends this output.

```
<dsig:KeyInfo>
<dsig:X509Data>
<dsig:X509Certificate>pem text redacted</dsig:X509Certificate>
```


But I need it like this:

```
<dsig:X509Data>
   <dsig:X509IssuerSerial>
     <dsig:X509IssuerName>redacted</dsig:X509IssuerName>
     <dsig:X509SerialNumber>redacted</dsig:X509SerialNumber>
  </dsig:X509IssuerSerial>
  <dsig:X509Certificate>pem text redacted</dsig:X509Certificate>
</dsig:X509Data>
```

I feel like exposing the raw xmlsec library would make it easier to roll your own in this case.  Right now the builder doesn't support it.  Would you be opposed to a PR that just exposes some functionality that wrap xmlsecs native functions that I'd need to get this?  Or I could update the builder with something like `add_x509_data_with_issuer_name_and_isuer_serial`

Let me know, this dsig change I think will be helpful to more than just me, at anyrate.