### PR TITLE
Upgrade bindgen to 0.65

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ lazy_static = {version = "^1.4"}
 
 [build-dependencies]
 pkg-config = {version = "^0.3"}
-bindgen    = {version = "^0.59"}
+bindgen    = {version = "^0.65"}

--- a/bindings.rs
+++ b/bindings.rs
@@ -35,7 +35,6 @@ fn main()
             .clang_args(fetch_xmlsec_config_flags())
             .clang_args(fetch_xmlsec_config_libs())
             .layout_tests(true)
-            .rustfmt_bindings(true)
             .generate_comments(true);
 
         let bindings = bindbuild.generate()


### PR DESCRIPTION
bindgen 0.59 doesn't work with newer clang versions.