### PR TITLE
Allow building on windows with vcpkg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ Cargo.lock
 
 # Editor and IDE environments
 .vscode/
+/target-wsl
+/vcpkg_installed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,22 +1,25 @@
 [package]
-name         = "xmlsec"
-version      = "0.2.3"
-authors      = ["Leonhard Weber <leonhard.weber@voipir.cl>"]
-edition      = "2021"
-readme       = "README.md"
-license      = "MIT"
-description  = "Wrapper for xmlsec1 library"
-homepage     = "https://github.com/voipir/rust-xmlsec"
-repository   = "https://github.com/voipir/rust-xmlsec"
-keywords     = ["xml", "xmlsec", "dsig"]
+name = "xmlsec"
+version = "0.2.3"
+authors = ["Leonhard Weber <leonhard.weber@voipir.cl>"]
+edition = "2021"
+readme = "README.md"
+license = "MIT"
+description = "Wrapper for xmlsec1 library"
+homepage = "https://github.com/voipir/rust-xmlsec"
+repository = "https://github.com/voipir/rust-xmlsec"
+keywords = ["xml", "xmlsec", "dsig"]
 
 build = "bindings.rs"
 
 [dependencies]
-libc        = {version = "^0.2"}
-libxml      = {version = "^0.3"}
-lazy_static = {version = "^1.4"}
+libc = { version = "^0.2" }
+libxml = { version = "^0.3" }
+lazy_static = { version = "^1.4" }
 
 [build-dependencies]
-pkg-config = {version = "^0.3"}
-bindgen    = {version = "^0.65"}
+pkg-config = { version = "^0.3" }
+bindgen = { version = "^0.71" }
+
+[target.'cfg(windows)'.build-dependencies]
+vcpkg = { version = "0.2", git = "https://github.com/mcgoo/vcpkg-rs.git", branch = "master" }

--- a/src/crypto/openssl.rs
+++ b/src/crypto/openssl.rs
@@ -3,11 +3,9 @@
 //!
 use crate::bindings;
 
-
 /// Supported digesting and signing methods as specified by the XML standard.
 #[allow(missing_docs)]
-pub enum XmlSecSignatureMethod
-{
+pub enum XmlSecSignatureMethod {
     Aes128Cbc,
     Aes192Cbc,
     Aes256Cbc,
@@ -26,16 +24,16 @@ pub enum XmlSecSignatureMethod
     EcdsaSha256,
     EcdsaSha384,
     EcdsaSha512,
-    HmacMd5,
+    // HmacMd5,
     HmacRipemd160,
     HmacSha1,
     HmacSha224,
     HmacSha256,
     HmacSha384,
     HmacSha512,
-    Md5,
+    // Md5,
     Ripemd160,
-    RsaMd5,
+    // RsaMd5,
     RsaRipemd160,
     RsaSha1,
     RsaSha224,
@@ -51,55 +49,53 @@ pub enum XmlSecSignatureMethod
     Sha512,
 }
 
-
-impl XmlSecSignatureMethod
-{
+impl XmlSecSignatureMethod {
     /// Returns the resource pointer for the corresponding digesting/signing resource
-    pub fn to_method(&self) -> bindings::xmlSecTransformId
-    {
-        match self
-        {
-            Self::Aes128Cbc     => unsafe { bindings::xmlSecOpenSSLTransformAes128CbcGetKlass() },
-            Self::Aes192Cbc     => unsafe { bindings::xmlSecOpenSSLTransformAes192CbcGetKlass() },
-            Self::Aes256Cbc     => unsafe { bindings::xmlSecOpenSSLTransformAes256CbcGetKlass() },
+    pub fn to_method(&self) -> bindings::xmlSecTransformId {
+        match self {
+            Self::Aes128Cbc => unsafe { bindings::xmlSecOpenSSLTransformAes128CbcGetKlass() },
+            Self::Aes192Cbc => unsafe { bindings::xmlSecOpenSSLTransformAes192CbcGetKlass() },
+            Self::Aes256Cbc => unsafe { bindings::xmlSecOpenSSLTransformAes256CbcGetKlass() },
             // Self::Aes128Gcm     => unsafe { bindings::xmlSecOpenSSLTransformAes128GcmGetKlass() },
             // Self::Aes192Gcm     => unsafe { bindings::xmlSecOpenSSLTransformAes192GcmGetKlass() },
             // Self::Aes256Gcm     => unsafe { bindings::xmlSecOpenSSLTransformAes256GcmGetKlass() },
-            Self::KWAes128      => unsafe { bindings::xmlSecOpenSSLTransformKWAes128GetKlass() },
-            Self::KWAes192      => unsafe { bindings::xmlSecOpenSSLTransformKWAes192GetKlass() },
-            Self::KWAes256      => unsafe { bindings::xmlSecOpenSSLTransformKWAes256GetKlass() },
-            Self::Des3Cbc       => unsafe { bindings::xmlSecOpenSSLTransformDes3CbcGetKlass() },
-            Self::KWDes3        => unsafe { bindings::xmlSecOpenSSLTransformKWDes3GetKlass() },
-            Self::DsaSha1       => unsafe { bindings::xmlSecOpenSSLTransformDsaSha1GetKlass() },
-            Self::DsaSha256     => unsafe { bindings::xmlSecOpenSSLTransformDsaSha256GetKlass() },
-            Self::EcdsaSha1     => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha1GetKlass() },
-            Self::EcdsaSha224   => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha224GetKlass() },
-            Self::EcdsaSha256   => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha256GetKlass() },
-            Self::EcdsaSha384   => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha384GetKlass() },
-            Self::EcdsaSha512   => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha512GetKlass() },
-            Self::HmacMd5       => unsafe { bindings::xmlSecOpenSSLTransformHmacMd5GetKlass() },
-            Self::HmacRipemd160 => unsafe { bindings::xmlSecOpenSSLTransformHmacRipemd160GetKlass() },
-            Self::HmacSha1      => unsafe { bindings::xmlSecOpenSSLTransformHmacSha1GetKlass() },
-            Self::HmacSha224    => unsafe { bindings::xmlSecOpenSSLTransformHmacSha224GetKlass() },
-            Self::HmacSha256    => unsafe { bindings::xmlSecOpenSSLTransformHmacSha256GetKlass() },
-            Self::HmacSha384    => unsafe { bindings::xmlSecOpenSSLTransformHmacSha384GetKlass() },
-            Self::HmacSha512    => unsafe { bindings::xmlSecOpenSSLTransformHmacSha512GetKlass() },
-            Self::Md5           => unsafe { bindings::xmlSecOpenSSLTransformMd5GetKlass() },
-            Self::Ripemd160     => unsafe { bindings::xmlSecOpenSSLTransformRipemd160GetKlass() },
-            Self::RsaMd5        => unsafe { bindings::xmlSecOpenSSLTransformRsaMd5GetKlass() },
-            Self::RsaRipemd160  => unsafe { bindings::xmlSecOpenSSLTransformRsaRipemd160GetKlass() },
-            Self::RsaSha1       => unsafe { bindings::xmlSecOpenSSLTransformRsaSha1GetKlass() },
-            Self::RsaSha224     => unsafe { bindings::xmlSecOpenSSLTransformRsaSha224GetKlass() },
-            Self::RsaSha256     => unsafe { bindings::xmlSecOpenSSLTransformRsaSha256GetKlass() },
-            Self::RsaSha384     => unsafe { bindings::xmlSecOpenSSLTransformRsaSha384GetKlass() },
-            Self::RsaSha512     => unsafe { bindings::xmlSecOpenSSLTransformRsaSha512GetKlass() },
-            Self::RsaPkcs1      => unsafe { bindings::xmlSecOpenSSLTransformRsaPkcs1GetKlass() },
-            Self::RsaOaep       => unsafe { bindings::xmlSecOpenSSLTransformRsaOaepGetKlass() },
-            Self::Sha1          => unsafe { bindings::xmlSecOpenSSLTransformSha1GetKlass() },
-            Self::Sha224        => unsafe { bindings::xmlSecOpenSSLTransformSha224GetKlass() },
-            Self::Sha256        => unsafe { bindings::xmlSecOpenSSLTransformSha256GetKlass() },
-            Self::Sha384        => unsafe { bindings::xmlSecOpenSSLTransformSha384GetKlass() },
-            Self::Sha512        => unsafe { bindings::xmlSecOpenSSLTransformSha512GetKlass() },
+            Self::KWAes128 => unsafe { bindings::xmlSecOpenSSLTransformKWAes128GetKlass() },
+            Self::KWAes192 => unsafe { bindings::xmlSecOpenSSLTransformKWAes192GetKlass() },
+            Self::KWAes256 => unsafe { bindings::xmlSecOpenSSLTransformKWAes256GetKlass() },
+            Self::Des3Cbc => unsafe { bindings::xmlSecOpenSSLTransformDes3CbcGetKlass() },
+            Self::KWDes3 => unsafe { bindings::xmlSecOpenSSLTransformKWDes3GetKlass() },
+            Self::DsaSha1 => unsafe { bindings::xmlSecOpenSSLTransformDsaSha1GetKlass() },
+            Self::DsaSha256 => unsafe { bindings::xmlSecOpenSSLTransformDsaSha256GetKlass() },
+            Self::EcdsaSha1 => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha1GetKlass() },
+            Self::EcdsaSha224 => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha224GetKlass() },
+            Self::EcdsaSha256 => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha256GetKlass() },
+            Self::EcdsaSha384 => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha384GetKlass() },
+            Self::EcdsaSha512 => unsafe { bindings::xmlSecOpenSSLTransformEcdsaSha512GetKlass() },
+            // Self::HmacMd5 => unsafe { bindings::xmlSecOpenSSLTransformHmacMd5GetKlass() },
+            Self::HmacRipemd160 => unsafe {
+                bindings::xmlSecOpenSSLTransformHmacRipemd160GetKlass()
+            },
+            Self::HmacSha1 => unsafe { bindings::xmlSecOpenSSLTransformHmacSha1GetKlass() },
+            Self::HmacSha224 => unsafe { bindings::xmlSecOpenSSLTransformHmacSha224GetKlass() },
+            Self::HmacSha256 => unsafe { bindings::xmlSecOpenSSLTransformHmacSha256GetKlass() },
+            Self::HmacSha384 => unsafe { bindings::xmlSecOpenSSLTransformHmacSha384GetKlass() },
+            Self::HmacSha512 => unsafe { bindings::xmlSecOpenSSLTransformHmacSha512GetKlass() },
+            // Self::Md5 => unsafe { bindings::xmlSecOpenSSLTransformMd5GetKlass() },
+            Self::Ripemd160 => unsafe { bindings::xmlSecOpenSSLTransformRipemd160GetKlass() },
+            // Self::RsaMd5 => unsafe { bindings::xmlSecOpenSSLTransformRsaMd5GetKlass() },
+            Self::RsaRipemd160 => unsafe { bindings::xmlSecOpenSSLTransformRsaRipemd160GetKlass() },
+            Self::RsaSha1 => unsafe { bindings::xmlSecOpenSSLTransformRsaSha1GetKlass() },
+            Self::RsaSha224 => unsafe { bindings::xmlSecOpenSSLTransformRsaSha224GetKlass() },
+            Self::RsaSha256 => unsafe { bindings::xmlSecOpenSSLTransformRsaSha256GetKlass() },
+            Self::RsaSha384 => unsafe { bindings::xmlSecOpenSSLTransformRsaSha384GetKlass() },
+            Self::RsaSha512 => unsafe { bindings::xmlSecOpenSSLTransformRsaSha512GetKlass() },
+            Self::RsaPkcs1 => unsafe { bindings::xmlSecOpenSSLTransformRsaPkcs1GetKlass() },
+            Self::RsaOaep => unsafe { bindings::xmlSecOpenSSLTransformRsaOaepGetKlass() },
+            Self::Sha1 => unsafe { bindings::xmlSecOpenSSLTransformSha1GetKlass() },
+            Self::Sha224 => unsafe { bindings::xmlSecOpenSSLTransformSha224GetKlass() },
+            Self::Sha256 => unsafe { bindings::xmlSecOpenSSLTransformSha256GetKlass() },
+            Self::Sha384 => unsafe { bindings::xmlSecOpenSSLTransformSha384GetKlass() },
+            Self::Sha512 => unsafe { bindings::xmlSecOpenSSLTransformSha512GetKlass() },
         }
     }
 }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -15,23 +15,20 @@ use std::os::raw::c_uchar;
 use std::ffi::CStr;
 use std::ffi::CString;
 
-
 /// x509 key format.
 #[allow(missing_docs)]
 #[repr(u32)]
-pub enum XmlSecKeyFormat
-{
-    Unknown  = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatUnknown,
-    Binary   = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatBinary,
-    Pem      = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPem,
-    Der      = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatDer,
-    Pkcs8Pem = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPkcs8Pem,
-    Pkcs8Der = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPkcs8Der,
-    Pkcs12   = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPkcs12,
-    CertPem  = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatCertPem,
-    CertDer  = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatCertDer,
+pub enum XmlSecKeyFormat {
+    Unknown = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatUnknown as u32,
+    Binary = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatBinary as u32,
+    Pem = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPem as u32,
+    Der = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatDer as u32,
+    Pkcs8Pem = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPkcs8Pem as u32,
+    Pkcs8Der = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPkcs8Der as u32,
+    Pkcs12 = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatPkcs12 as u32,
+    CertPem = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatCertPem as u32,
+    CertDer = bindings::xmlSecKeyDataFormat_xmlSecKeyDataFormatCertDer as u32,
 }
-
 
 /// Key with which we sign/verify signatures or encrypt data. Used by [`XmlSecSignatureContext`][sigctx].
 ///
@@ -39,32 +36,34 @@ pub enum XmlSecKeyFormat
 #[derive(Debug)]
 pub struct XmlSecKey(*mut bindings::xmlSecKey);
 
-
-impl XmlSecKey
-{
+impl XmlSecKey {
     /// Load key from file by specifying path, its format in the file, and optionally the password required to
     /// decrypt/unlock.
-    pub fn from_file(path: &str, format: XmlSecKeyFormat, password: Option<&str>) -> XmlSecResult<Self>
-    {
+    pub fn from_file(
+        path: &str,
+        format: XmlSecKeyFormat,
+        password: Option<&str>,
+    ) -> XmlSecResult<Self> {
         // TODO deprecate internals for Rust read-from-file and then loading with `from_memory`
 
         crate::xmlsec::guarantee_xmlsec_init();
 
         // TODO proper sanitization/error handling of input
-        let cpath   = CString::new(path).unwrap();
+        let cpath = CString::new(path).unwrap();
         let cpasswd = password.map(|p| CString::new(p).unwrap());
 
-        let cpasswd_ptr = cpasswd.map(|cstr| cstr.as_ptr())
-            .unwrap_or(null());
+        let cpasswd_ptr = cpasswd.map(|cstr| cstr.as_ptr()).unwrap_or(null());
 
         // Load key from file
-        let key = unsafe { bindings::xmlSecOpenSSLAppKeyLoad(
-            cpath.as_ptr(),
-            format as u32,
-            cpasswd_ptr,
-            null_mut(),
-            null_mut()
-        ) };
+        let key = unsafe {
+            bindings::xmlSecOpenSSLAppKeyLoad(
+                cpath.as_ptr(),
+                format as bindings::xmlSecKeyDataFormat,
+                cpasswd_ptr,
+                null_mut(),
+                null_mut(),
+            )
+        };
 
         if key.is_null() {
             return Err(XmlSecError::KeyLoadError);
@@ -74,25 +73,29 @@ impl XmlSecKey
     }
 
     /// Load key from buffer in memory, specifying format and optionally the password required to decrypt/unlock.
-    pub fn from_memory(buffer: &[u8], format: XmlSecKeyFormat, password: Option<&str>) -> XmlSecResult<Self>
-    {
+    pub fn from_memory(
+        buffer: &[u8],
+        format: XmlSecKeyFormat,
+        password: Option<&str>,
+    ) -> XmlSecResult<Self> {
         crate::xmlsec::guarantee_xmlsec_init();
 
         // TODO proper sanitization/error handling of input
         let cpasswd = password.map(|p| CString::new(p).unwrap());
 
-        let cpasswd_ptr = cpasswd.map(|cstr| cstr.as_ptr())
-            .unwrap_or(null());
+        let cpasswd_ptr = cpasswd.map(|cstr| cstr.as_ptr()).unwrap_or(null());
 
         // Load key from buffer
-        let key = unsafe { bindings::xmlSecOpenSSLAppKeyLoadMemory(
-            buffer.as_ptr(),
-            buffer.len() as u32,
-            format as u32,
-            cpasswd_ptr,
-            null_mut(),
-            null_mut()
-        ) };
+        let key = unsafe {
+            bindings::xmlSecOpenSSLAppKeyLoadMemory(
+                buffer.as_ptr(),
+                buffer.len() as u32,
+                format as bindings::xmlSecKeyDataFormat,
+                cpasswd_ptr,
+                null_mut(),
+                null_mut(),
+            )
+        };
 
         if key.is_null() {
             return Err(XmlSecError::KeyLoadError);
@@ -102,11 +105,16 @@ impl XmlSecKey
     }
 
     /// Load certificate into key by specifying path and ints format.
-    pub fn load_cert_from_file(&self, path: &str, format: XmlSecKeyFormat) -> XmlSecResult<()>
-    {
+    pub fn load_cert_from_file(&self, path: &str, format: XmlSecKeyFormat) -> XmlSecResult<()> {
         let cpath = CString::new(path).unwrap();
 
-        let rc = unsafe { bindings::xmlSecOpenSSLAppKeyCertLoad(self.0, cpath.as_ptr(), format as u32) };
+        let rc = unsafe {
+            bindings::xmlSecOpenSSLAppKeyCertLoad(
+                self.0,
+                cpath.as_ptr(),
+                format as bindings::xmlSecKeyDataFormat,
+            )
+        };
 
         if rc != 0 {
             return Err(XmlSecError::CertLoadError);
@@ -116,14 +124,13 @@ impl XmlSecKey
     }
 
     /// Load certificate into key by specifying buffer to its contents.
-    pub fn load_cert_from_memory(&self, buff: &[u8], format: XmlSecKeyFormat) -> XmlSecResult<()>
-    {
+    pub fn load_cert_from_memory(&self, buff: &[u8], format: XmlSecKeyFormat) -> XmlSecResult<()> {
         let rc = unsafe {
             bindings::xmlSecOpenSSLAppKeyCertLoadMemory(
                 self.0,
                 buff.as_ptr(),
                 buff.len() as u32,
-                format as u32
+                format as bindings::xmlSecKeyDataFormat,
             )
         };
 
@@ -135,43 +142,36 @@ impl XmlSecKey
     }
 
     /// Set name of the key.
-    pub fn set_name(&mut self, name: &str)
-    {
+    pub fn set_name(&mut self, name: &str) {
         let cname = CString::new(name).unwrap();
 
-        let rc = unsafe { bindings::xmlSecKeySetName(
-            self.0,
-            cname.as_ptr() as *const c_uchar
-        ) };
+        let rc = unsafe { bindings::xmlSecKeySetName(self.0, cname.as_ptr() as *const c_uchar) };
 
         if rc < 0 {
-            panic!("Failed to set name for key");   // TODO proper error handling
+            panic!("Failed to set name for key"); // TODO proper error handling
         }
     }
 
     /// Get the name currently set for the key.
-    pub fn get_name(&self) -> &str
-    {
-        let raw   = unsafe { bindings::xmlSecKeyGetName(self.0) };
+    pub fn get_name(&self) -> &str {
+        let raw = unsafe { bindings::xmlSecKeyGetName(self.0) };
         let cname = unsafe { CStr::from_ptr(raw as *const c_char) };
 
-        cname.to_str().unwrap()  // TODO proper error handling
+        cname.to_str().unwrap() // TODO proper error handling
     }
 
     /// # Safety
     ///
     /// Create from raw pointer to an underlying xmlsec key structure. Henceforth its lifetime will be managed by this
     /// object.
-    pub unsafe fn from_ptr(ptr: *mut bindings::xmlSecKey) -> Self
-    {
+    pub unsafe fn from_ptr(ptr: *mut bindings::xmlSecKey) -> Self {
         Self(ptr)
     }
 
     /// # Safety
     ///
     /// Returns a raw pointer to the underlying xmlsec structure.
-    pub unsafe fn as_ptr(&self) -> *mut bindings::xmlSecKey
-    {
+    pub unsafe fn as_ptr(&self) -> *mut bindings::xmlSecKey {
         self.0
     }
 
@@ -182,8 +182,7 @@ impl XmlSecKey
     /// verification.
     ///
     /// [sigctx]: struct.XmlSecSignatureContext.html
-    pub unsafe fn leak(key: Self) -> *mut bindings::xmlSecKey
-    {
+    pub unsafe fn leak(key: Self) -> *mut bindings::xmlSecKey {
         let ptr = key.0;
 
         std::mem::forget(key);
@@ -192,34 +191,24 @@ impl XmlSecKey
     }
 }
 
-
-impl PartialEq for XmlSecKey
-{
-    fn eq(&self, other: &Self) -> bool
-    {
-        self.0 == other.0  // compare pointer addresses
+impl PartialEq for XmlSecKey {
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0 // compare pointer addresses
     }
 }
 
-
 impl Eq for XmlSecKey {}
 
-
-impl Clone for XmlSecKey
-{
-    fn clone(&self) -> Self
-    {
+impl Clone for XmlSecKey {
+    fn clone(&self) -> Self {
         let new = unsafe { bindings::xmlSecKeyDuplicate(self.0) };
 
         Self(new)
     }
 }
 
-
-impl Drop for XmlSecKey
-{
-    fn drop(&mut self)
-    {
+impl Drop for XmlSecKey {
+    fn drop(&mut self) {
         unsafe { bindings::xmlSecKeyDestroy(self.0) };
     }
 }

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "builtin-baseline": "1faad557cd7435901d7eac7b0b7f38e3e865701c",
+  "dependencies": ["libxslt", "xmlsec"],
+  "overrides": [
+    {
+      "name": "xmlsec",
+      "version": "1.2.37"
+    }
+  ]
+}


### PR DESCRIPTION
This was annoying because vcpkg has xmlsec 1.3, which contains breaking changes compared to 1.2, whereas linux distros are still packaging 1.2. There's no way to get older versions of a package with vcpkg unless you use a manifest (as I have done here) but the rust vcpkg crate does not support manifests, so I had to use a fork which does...